### PR TITLE
Add :before_feedback and :after_feedback yields to send_feedback

### DIFF
--- a/lib/pg/replication/version.rb
+++ b/lib/pg/replication/version.rb
@@ -1,5 +1,5 @@
 module PG
   class Replication
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/pg_replication.rb
+++ b/lib/pg_replication.rb
@@ -386,6 +386,8 @@ class PG::Replicator
   end
 
   def send_feedback
+    yield(:before_feedback) if block_given?
+
     @last_status_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     timestamp = ((Time.now - EPOCH) * 1000000).to_i
 
@@ -407,10 +409,7 @@ class PG::Replicator
     connection.put_copy_data(msg)
     connection.flush
 
-    # Yield nil to notify the caller that a feedback message was sent.
-    # This allows users to track when feedback occurs (e.g., for logging or
-    # breaking out of the replication loop after catching up).
-    yield(nil) if block_given?
+    yield(:after_feedback) if block_given?
   end
 
 end

--- a/test/pg_replication_test.rb
+++ b/test/pg_replication_test.rb
@@ -67,7 +67,7 @@ class PGReplicationTest < Minitest::Test
     assert_equal 0, replicator.last_processed_lsn
 
     replicator.replicate do |res|
-      results << res
+      results << res if res.is_a?(String)
       break if results.size >= 5
     end
 
@@ -119,7 +119,7 @@ class PGReplicationTest < Minitest::Test
     assert_equal 0, replicator.last_processed_lsn
 
     replicator.replicate do |res|
-      results << res
+      results << res if res.is_a?(String)
     end
 
     assert_equal lsn(endpos), lsn(replicator.last_received_lsn)
@@ -173,7 +173,7 @@ class PGReplicationTest < Minitest::Test
     assert_equal 0, replicator.last_processed_lsn
 
     replicator.replicate do |res|
-      results << res
+      results << res if res.is_a?(String)
     end
 
     assert_equal lsn(endpos), lsn(replicator.last_received_lsn)
@@ -211,6 +211,7 @@ class PGReplicationTest < Minitest::Test
     t = Thread.new do
       results = []
       replicator.replicate do |res|
+        next unless res.is_a?(String)
         results << res
         sleep(0.1) while pause_replication
         Thread.exit if results.size >= 5
@@ -434,10 +435,16 @@ class PGReplicationTest < Minitest::Test
       replication_options: { "include-timestamp" => true },
     }).select { |_, v| !v.nil? })
 
-    # Feedback is nil wal log
+    feedback_signals = []
     replicator.replicate do |wal|
-      break if wal.nil?
+      if wal.is_a?(Symbol)
+        feedback_signals << wal
+        break if wal == :after_feedback
+      end
     end
+
+    assert_includes feedback_signals, :before_feedback
+    assert_includes feedback_signals, :after_feedback
   end
 
   def test_stop
@@ -456,7 +463,7 @@ class PGReplicationTest < Minitest::Test
     results = []
     t = Thread.new do
       replicator.replicate do |wal|
-        results << wal if wal
+        results << wal if wal.is_a?(String)
       end
     end
 
@@ -492,7 +499,7 @@ class PGReplicationTest < Minitest::Test
 
     # replicate_async should return self for fluent interface
     ret = replicator.replicate_async do |wal|
-      results << wal if wal
+      results << wal if wal.is_a?(String)
     end
     assert_same replicator, ret
 


### PR DESCRIPTION
## Summary

- Replace `yield(nil)` in `send_feedback` with `yield(:before_feedback)` before and `yield(:after_feedback)` after the feedback message is sent to PostgreSQL
- Bump version to 0.3.0 (breaking change: block yields change from `nil` to symbols)
- Update all tests to filter WAL payloads with `is_a?(String)` and add assertions for the new feedback signals

## Breaking Change

Consumers that relied on `yield(nil)` to detect feedback (e.g., `break if wal.nil?` or `results << wal if wal`) will need to update their block logic to handle `:before_feedback` and `:after_feedback` symbols instead.

## Test plan

- [x] All 14 existing tests pass (`bundle exec rake test`)
- [x] `test_feedback_callback` asserts both `:before_feedback` and `:after_feedback` are received
- [ ] Verify downstream consumers (e.g., `PostgresJob` in changebase/hub) handle the new symbols correctly

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)